### PR TITLE
Add informative startup messages

### DIFF
--- a/control/src/aegir/controller.py
+++ b/control/src/aegir/controller.py
@@ -64,6 +64,7 @@ class AegirController():
 
         # Create a logger for system events that can be retrieved by client requests
         self.logger = AegirEventLogger(logging.getLogger())
+        self.logger.info("System starting up")
 
         # Initialise the values of the parameter tree and packet information
         self.status = PacketReceiveState.UNKNOWN
@@ -128,7 +129,7 @@ class AegirController():
 
         # Launch the packet receive task in the background
         if self.receive_task_enable:
-            self.logger.debug("Launching packet receive task")
+            self.logger.info("Launching packet receive task")
             self.receive_packets()
 
     def get(self, path):

--- a/control/src/aegir/outlet_relay.py
+++ b/control/src/aegir/outlet_relay.py
@@ -49,7 +49,7 @@ class OutletRelay():
         self.enabled = enabled
         self.state = state
 
-        self.logger.debug("%s outlet initialised", self.name)
+        self.logger.info("%s outlet initialised", self.name)
 
     def set_enabled(self, enable):
         """


### PR DESCRIPTION
This PR modifies the log level of some existing messages emitted at startup, plus a new overall message. This is to allow informative messages to be placed in the UI logger when the control system starts, which don't require debug level logging.