### PR TITLE
Support Debian 11

### DIFF
--- a/control/setup.cfg
+++ b/control/setup.cfg
@@ -8,7 +8,7 @@ package_dir=
     =src
 packages=find:
 install_requires =
-    odin-control @ git+https://github.com/odin-detector/odin-control@1.3.0#egg=odin-control
+    odin-control @ git+https://github.com/odin-detector/odin-control@1.6.0#egg=odin-control
     pyserial
     Adafruit_BBIO
 

--- a/control/src/hxtleak/packet_decoder.py
+++ b/control/src/hxtleak/packet_decoder.py
@@ -57,7 +57,7 @@ class HxtleakPacketDecoder(struct.Struct):
 
         def _status_bit_set(bit_value):
 
-            return (self.sensor_status & bit_value) != 0
+            return self.sensor_status and ((self.sensor_status & bit_value) != 0)
 
         for bit in HxtleakSensorStatus:
             setattr(self, bit.name.lower(), partial(_status_bit_set, bit.value))

--- a/deploy/ansible/deploy_hxtleak.yml
+++ b/deploy/ansible/deploy_hxtleak.yml
@@ -11,7 +11,7 @@
     - name: Check if reboot required
       ansible.builtin.stat:
         path: /var/run/reboot-required
-        get_md5: no
+        get_checksum: no
       register: reboot_required
       changed_when: false
 
@@ -42,7 +42,6 @@
         enabled: false
       with_items:
         - wpa_supplicant
-        - bonescript-autorun
         - nginx
       tags: system
 
@@ -95,20 +94,16 @@
           - plugdev
           - users
           - systemd-journal
+          - input
+          - render
           - bluetooth
           - netdev
           - i2c
-          - gpio
-          - pwm
-          - eqep
-          - remoteproc
-          - admin
-          - spi
-          - iio
-          - docker
-          - tisdk
+          - cloud9ide
           - weston-launch
-          - xenomai
+          - tisdk
+          - admin
+          - gpio
       tags: user
 
     - name: Remove default debian account
@@ -124,8 +119,13 @@
         name:
           - python3
           - python3-pip
-          - python3-virtualenv
       tags: [package,python]
+
+    - name: Install virtualenv via pip
+      ansible.builtin.pip:
+        name: virtualenv
+        state: latest
+      tags: python
 
     - name: Create hexitex software directory
       ansible.builtin.file:
@@ -150,6 +150,7 @@
         name: "git+{{ hxtleak_repo_url }}.git@{{ hxtleak_release }}#egg=hxtleak&subdirectory=control"
         virtualenv: "{{ hxt_install_dir}}"
         editable: yes
+        virtualenv_site_packages: true
       become: yes
       become_user: "{{ hxt_user }}"
       tags: app
@@ -211,6 +212,13 @@
         - { path: '/var/tmp', mode: '1777', size: '1M' }
         - { path: '/tmp', mode: '1777', size: '32M' }
       tags: fstab
+
+    - name: Enable UART1 device tree overlay in boot environment
+      ansible.builtin.lineinfile:
+        path: /boot/uEnv.txt
+        regexp: '^#uboot_overlay_addr0'
+        line: 'uboot_overlay_addr0=/lib/firmware/BB-UART1-00A0.dtbo'
+      tags: uart
 
     - name : Set rootfs read-only in fstab
       ansible.posix.mount:


### PR DESCRIPTION
This PR updates the ansible deployment playbook for compatibility with the Debian 11 BeagleBone black image. Tested with BBB Debian 11.7 IoT 2023-09-02. 

In addition the underlying odin-control version is updated to the latest release (1.6.0) and a minor bug fixed in status bit parsing, which can cause the odin-control adapter to crash early if no packet data is being received.